### PR TITLE
  fix: use element-wise `&` instead of Python `and` in augment_modality_label

### DIFF
--- a/scripts/diff_model_train.py
+++ b/scripts/diff_model_train.py
@@ -49,7 +49,7 @@ def augment_modality_label(modality_tensor, prob=0.1):
     torch.Tensor: The modified modality tensor with the applied augmentations.
     """
     # Randomly set elements that are smaller than 8 with probability `prob`
-    mask_ct = (modality_tensor <8) and (modality_tensor >=2)
+    mask_ct = (modality_tensor < 8) & (modality_tensor >= 2)
     prob_ct = torch.rand(modality_tensor.size(),device=modality_tensor.device) < prob
     modality_tensor[mask_ct & prob_ct] = 1
     


### PR DESCRIPTION
Fix a bug in `augment_modality_label` (`scripts/diff_model_train.py`, line 52) where Python's `and` operator is used instead of PyTorch's element-wise `&` for boolean tensor masking, causing a `RuntimeError` when `batch_size > 1`.

# Before (line 52):
  mask_ct = (modality_tensor < 8) and (modality_tensor >= 2)

  Python's and calls __bool__ on the left operand, which invokes
  tensor.__bool__(). PyTorch raises:

  RuntimeError: Boolean value of Tensor with more than one element is ambiguous.
  Use a.any() or a.all()

  when the tensor has more than one element (i.e., batch_size > 1).

  With batch_size=1 the single-element tensor happens to evaluate without
  error, so the bug is silent in that configuration but will crash any
  multi-sample batch.

  Note that the MRI branch on line 57 already uses & correctly:

  mask_mri = (modality_tensor >= 9)          # correct
  modality_tensor[mask_mri & prob_mri] = 8   # correct

  The CT branch is inconsistent with this pattern.
