### PR TITLE
Fix AttributeError when cfg_guidance_scale is missing from GPU infer configs

### DIFF
--- a/configs/config_infer.json
+++ b/configs/config_infer.json
@@ -25,5 +25,5 @@
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
     "modality": 1,
-    "cfg_guidance_scale": 0
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_16g_256x256x128.json
+++ b/configs/config_infer_16g_256x256x128.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_16g_256x256x256.json
+++ b/configs/config_infer_16g_256x256x256.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_16g_512x512x128.json
+++ b/configs/config_infer_16g_512x512x128.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_24g_256x256x256.json
+++ b/configs/config_infer_24g_256x256x256.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_24g_512x512x128.json
+++ b/configs/config_infer_24g_512x512x128.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_24g_512x512x512.json
+++ b/configs/config_infer_24g_512x512x512.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_32g_512x512x512.json
+++ b/configs/config_infer_32g_512x512x512.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_80g_512x512x512.json
+++ b/configs/config_infer_80g_512x512x512.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/configs/config_infer_80g_512x512x768.json
+++ b/configs/config_infer_80g_512x512x768.json
@@ -25,5 +25,6 @@
     "autoencoder": "$@autoencoder_def",
     "mask_generation_autoencoder": "$@mask_generation_autoencoder_def",
     "mask_generation_diffusion": "$@mask_generation_diffusion_def",
-    "modality": 1
+    "modality": 1,
+    "cfg_guidance_scale": 0.0
 }

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -116,6 +116,9 @@ def main():
     for k, v in config_infer_dict.items():
         setattr(args, k, v)
         logger.info(f"{k}: {v}")
+    if not hasattr(args, "cfg_guidance_scale"):
+        args.cfg_guidance_scale = 0
+        logger.info("cfg_guidance_scale: 0 (default)")
 
     #
     # ## Read in optional extra configuration setting - typically acceleration options (TRT)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -117,8 +117,8 @@ def main():
         setattr(args, k, v)
         logger.info(f"{k}: {v}")
     if not hasattr(args, "cfg_guidance_scale"):
-        args.cfg_guidance_scale = 0
-        logger.info("cfg_guidance_scale: 0 (default)")
+        args.cfg_guidance_scale = 0.0
+        logger.info("cfg_guidance_scale: 0.0 (default)")
 
     #
     # ## Read in optional extra configuration setting - typically acceleration options (TRT)


### PR DESCRIPTION
## Summary

Paired CT inference crashes with `AttributeError: 'Namespace' object has no attribute 'cfg_guidance_scale'` when using GPU preset configs such as `config_infer_16g_256x256x256.json`.

`scripts/inference.py` always passes `cfg_guidance_scale` into `LDMSampler`, but only `configs/config_infer.json` defines that field. Presets under `configs/config_infer_16g_*` and `configs/config_infer_24g_*` omit it, even though **README/docs** point users at those files for limited VRAM.

This change defaults `cfg_guidance_scale` to `0` when it is absent from the inference config, matching `config_infer.json` and disabling classifier-free guidance (the intended default).

## Root cause

- Inference parameters are loaded via `setattr(args, k, v)` from the `-i` JSON file.
- `LDMSampler(..., cfg_guidance_scale=args.cfg_guidance_scale)` runs unconditionally at the end of `main()`.
- GPU presets never set `cfg_guidance_scale`, so `args` lacks the attribute and inference fails **after** all model weights are loaded.

## Changes

- `scripts/inference.py`: if `cfg_guidance_scale` is not in the inference config, set it to `0` and log the default.

## How to reproduce (before fix)

```bash
pip install -r requirements.txt
export MONAI_DATA_DIRECTORY="./temp_work_dir"
python -m scripts.download_model_data --version rflow-ct --root_dir "./"

python -m scripts.inference \
  -t ./configs/config_network_rflow.json \
  -i ./configs/config_infer_16g_256x256x256.json \
  -e ./configs/environment_rflow-ct.json \
  --random-seed 0 \
  --version rflow-ct