### PR TITLE
Reorganize docs/inference.md + update live-demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Key capabilities:
 - **Brain MRI synthesis** with cross-sequence ControlNet for generating matched multi-contrast brain volumes (T1w, T2w, FLAIR, SWI)
 - **Variable resolution** with configurable volume size and voxel spacing for each generation
 
-**[Live Demo](https://build.nvidia.com/nvidia/maisi)** (no GPU required)
+**[Live Demo](https://huggingface.co/spaces/nvidia/nv-generate)** (no GPU required)
 
 ## News
 
@@ -267,7 +267,7 @@ This project will download and install additional third-party open source softwa
 - [NV-Generate-MR on HuggingFace](https://huggingface.co/nvidia/NV-Generate-MR) -- MR model weights and model card
 - [NV-Generate-MR-Brain on HuggingFace](https://huggingface.co/nvidia/NV-Generate-MR-Brain) -- Brain MRI model weights and model card
 - [MR-RATE on HuggingFace](https://huggingface.co/datasets/Forithmus/MR-RATE) -- Brain MRI model training data MR-RATE
-- [MAISI Live Demo](https://build.nvidia.com/nvidia/maisi) -- Try online without GPU
+- [MAISI Live Demo](https://huggingface.co/spaces/nvidia/nv-generate) -- Try online without GPU
 - [MAISI-v1 Paper (WACV 2025)](https://arxiv.org/pdf/2409.11169)
 - [MAISI-v2 Paper (AAAI 2026)](https://arxiv.org/pdf/2508.05772)
 - Built with [MONAI](https://monai.io/) -- Medical Open Network for AI

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -139,7 +139,7 @@ Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N
 
 > ℹ️ The table covers axial, sagittal, and coronal scans only. The training set also includes images acquired in oblique orientations (not summarized here); the model has seen those during training but they are excluded from this reference table because the axial/sagittal/coronal cases are what users typically request at inference.
 >
-> ⚠️ **MRA** has very few training images across all three planes (37 / 98 / 11), so output quality at `mri_mra` (16) / `mri_mra_skull_stripped` (33) is not guaranteed.
+> ⚠️ Some (modality, plane) combinations have very few training images — output quality is not guaranteed for: **MRA** all planes (37 / 98 / 11), **SWI sagittal** (2), **SWI coronal** (4).
 
 | Modality | Plane | Median FOV (mm) | N |
 |---|---|---|---:|

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -137,6 +137,8 @@ Contrast-enhanced MRI is not supported. For brain MRI, prefer the dedicated `rfl
 
 Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N` counts unique source images; whole-brain and skull-stripped share the same FOV since they're two preprocessings of the same subject. Total unique images per skull condition (sum of the rows below): **318 825**.
 
+> ℹ️ The table covers axial, sagittal, and coronal scans only. The training set also includes images acquired in oblique orientations (not summarized here); the model has seen those during training but they are excluded from this reference table because the axial/sagittal/coronal cases are what users typically request at inference.
+
 | Modality | Plane | Median FOV (mm) | N |
 |---|---|---|---:|
 | T1 | axial | 240 × 240 × 174 | 47 810 |

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -157,7 +157,7 @@ Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N
 | MRA | sagittal | 158 × 250 × 250 | 98 |
 | MRA | coronal | 240 × 179 × 240 | 11 |
 
-Pick the row matching your target acquisition plane, then pick the modality code for the skull condition you want (`9..20` whole-brain or `29..33` skull-stripped — see [Modality codes](#modality-codes)). Set `dim` and `spacing` so `dim[i] × spacing[i]` matches the median FOV; the slice-stacking axis (smallest FOV) should map to the smaller `dim` axis: axial → `dim[2]=128`, sagittal → `dim[0]=128`, coronal → `dim[1]=128`.
+Pick the row matching your target acquisition plane, then pick the modality code (see [Modality codes](#modality-codes); `9..20` for whole-brain or `29..33` for skull-stripped). The median FOV is a starting point — feel free to vary `dim` and `spacing` as long as `dim[i] × spacing[i]` lands near it.
 
 ## Modality codes
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,41 +1,101 @@
 # Inference Guide
 
-## Architecture
-
-The pipeline trains an autoencoder in pixel space to encode images into latent features, then trains a diffusion model in the latent space. During inference, latent features are generated from random noise via denoising steps, then decoded by the autoencoder.
-
-![Training scheme](../figures/maisi_train.png)
-
-![Inference scheme](../figures/maisi_infer.png)
-
-Network definitions: [config_network_rflow.json](../configs/config_network_rflow.json), [config_network_ddpm.json](../configs/config_network_ddpm.json). Key references: [Latent Diffusion (CVPR 2022)](https://openaccess.thecvf.com/content/CVPR2022/papers/Rombach_High-Resolution_Image_Synthesis_With_Latent_Diffusion_Models_CVPR_2022_paper.pdf), [ControlNet (ICCV 2023)](https://openaccess.thecvf.com/content/ICCV2023/papers/Zhang_Adding_Conditional_Control_to_Text-to-Image_Diffusion_Models_ICCV_2023_paper.pdf), [Rectified Flow (ICLR 2023)](https://arxiv.org/pdf/2209.03003).
+This guide covers how to run inference with each NV-Generate-CTMR variant, how to size the output volume (FOV) for your anatomy, and how to tune the runtime knobs. For a quick orientation see the README §2 quick-start; for end-to-end skill-style walkthroughs see [`skills/`](../skills/).
 
 ## Overview
 
-NV-Generate-CTMR supports several inference modes:
+NV-Generate-CTMR supports four inference modes, each backed by a different model variant:
 
-- **Paired CT image/mask generation** -- generates CT images with corresponding segmentation masks (using ControlNet)
-- **CT image-only generation** -- generates CT images without masks
-- **MR image-only generation** -- generates MR images with user-specified contrast
+| Mode | Variant | Skill |
+|---|---|---|
+| Paired CT image + segmentation mask | `rflow-ct`, `ddpm-ct` | [`infer_mask-image-paired`](../skills/infer_mask-image-paired.md) |
+| CT image only (no mask) | `rflow-ct`, `ddpm-ct` | [`infer_image-only`](../skills/infer_image-only.md) |
+| MR image only (non-brain — prostate / breast / abdomen) | `rflow-mr` | [`infer_image-only`](../skills/infer_image-only.md) |
+| MR brain image only (T1 / T2 / FLAIR / SWI, whole-brain or skull-stripped) | `rflow-mr-brain` | [`infer_image-only`](../skills/infer_image-only.md) |
 
-## Inference Parameters
+CT supports a ControlNet pipeline (mask-conditioned image synthesis); MR does not — there is no MR ControlNet in this repo.
 
-The information for the inference input, such as the body region and anatomy to generate, is stored in [../configs/config_infer.json](../configs/config_infer.json). Feel free to experiment with it. Below are the details of the parameters:
+## Execute inference
 
-- `"num_output_samples"`: An integer specifying the number of output image/mask pairs to generate.
-- `"spacing"`: The voxel size of the generated images. For example, if set to `[1.5, 1.5, 2.0]`, it generates images with a resolution of 1.5x1.5x2.0 mm.
-- `"output_size"`: The volume size of the generated images. For example, if set to `[512, 512, 256]`, it generates images of size 512x512x256. The values must be divisible by 16. If GPU memory is limited, adjust these to smaller numbers. Note that `"spacing"` and `"output_size"` together determine the output field of view (FOV). For example, if set to `[1.5, 1.5, 2.0]` mm and `[512, 512, 256]`, the FOV is 768x768x512 mm. We recommend the FOV in the x and y axes to be at least 256 mm for the head and at least 384 mm for other body regions like the abdomen. There is no restriction for the z-axis.
-- `"controllable_anatomy_size"`: A list specifying controllable anatomy and their size scale (0-1). For example, if set to `[["liver", 0.5], ["hepatic tumor", 0.3]]`, the generated image will contain a liver of median size (around the 50th percentile) and a relatively small hepatic tumor (around the 30th percentile). The output will include paired images and segmentation masks for the controllable anatomy.
-- `"body_region"`: For `maisi3d_rflow`, it is deprecated and can be set as `[]`. The output body region will be determined by `"anatomy_list"`. For `maisi3d_ddpm`, if `"controllable_anatomy_size"` is not specified, `"body_region"` will constrain the region of the generated images. It must be chosen from `"head"`, `"chest"`, `"thorax"`, `"abdomen"`, `"pelvis"`, or `"lower"`. Please set a reasonable `"body_region"` for the given FOV determined by `"spacing"` and `"output_size"`. For example, if FOV is only 128mm in z-axis, we should not expect `"body_region"` to contain all of [`"head"`, `"chest"`, `"thorax"`, `"abdomen"`, `"pelvis"`, `"lower"`].
-- `"anatomy_list"`: If `"controllable_anatomy_size"` is not specified, the output will include paired images and segmentation masks for the anatomy listed in `"../configs/label_dict.json"`.
-- `"autoencoder_sliding_window_infer_size"`: To save GPU memory, sliding window inference is used when decoding latents into images if `"output_size"` is large. This parameter specifies the patch size of the sliding window. Smaller values reduce GPU memory usage but increase the time cost. The values must be divisible by 16. If GPU memory is sufficient, select a larger value for this parameter.
-- `"autoencoder_sliding_window_infer_overlap"`: A float between 0 and 1. Larger values reduce stitching artifacts when patches are stitched during sliding window inference but increase the time cost. If you do not observe seam lines in the generated image, you can use a smaller value to save inference time.
-- `"autoencoder_tp_num_splits"`: An integer chosen from `[1, 2, 4, 8, 16]`. Tensor parallelism is used in the autoencoder to save GPU memory. Larger values reduce GPU memory usage. If GPU memory is sufficient, select a smaller value for this parameter.
+### Paired CT image + mask
+
+```bash
+export MONAI_DATA_DIRECTORY=<dir_you_will_download_data>
+network="rflow"                       # or "ddpm" for ddpm-ct
+generate_version="rflow-ct"           # or "ddpm-ct"
+
+python -m scripts.inference \
+    -t ./configs/config_network_${network}.json \
+    -i ./configs/config_infer.json \
+    -e ./configs/environment_${generate_version}.json \
+    --random-seed 0 --version ${generate_version}
+```
+
+> ⚠️ `ddpm-ct` requires `"num_inference_steps": 1000` in `config_infer.json`. `rflow-ct` uses `30`. Lower DDPM step counts emit a warning and produce low-quality output.
+
+There is currently no ControlNet for MRI — MR variability is too large to train one whole-body model. See [inference_tutorial.ipynb](../inference_tutorial.ipynb) for an end-to-end notebook walkthrough of the CT paired case.
+
+### CT image only (no mask)
+
+```bash
+network="rflow"                       # or "ddpm" for ddpm-ct
+generate_version="rflow-ct"           # or "ddpm-ct"
+
+python -m scripts.download_model_data --version ${generate_version} --root_dir "./" --model_only
+python -m scripts.diff_model_infer \
+    -t ./configs/config_network_${network}.json \
+    -e ./configs/environment_maisi_diff_model_${generate_version}.json \
+    -c ./configs/config_maisi_diff_model_${generate_version}.json
+```
+
+### MR image only (non-brain — `rflow-mr`)
+
+```bash
+network="rflow"
+generate_version="rflow-mr"
+
+python -m scripts.download_model_data --version ${generate_version} --root_dir "./" --model_only
+python -m scripts.diff_model_infer \
+    -t ./configs/config_network_${network}.json \
+    -e ./configs/environment_maisi_diff_model_${generate_version}.json \
+    -c ./configs/config_maisi_diff_model_${generate_version}.json
+```
+
+Set `"modality"` in `config_maisi_diff_model_rflow-mr.json` per the [Modality codes](#modality-codes) table below. For brain MRI prefer the dedicated `rflow-mr-brain` model.
+
+### MR brain image only (`rflow-mr-brain`)
+
+```bash
+network="rflow"
+generate_version="rflow-mr-brain"
+
+python -m scripts.download_model_data --version ${generate_version} --root_dir "./" --model_only
+python -m scripts.diff_model_infer \
+    -t ./configs/config_network_${network}.json \
+    -e ./configs/environment_maisi_diff_model_${generate_version}.json \
+    -c ./configs/config_maisi_diff_model_${generate_version}.json
+```
+
+Whole-brain (modality 9, 10, 11, 20) and skull-stripped (29, 30, 31, 32) outputs are both supported — see [Modality codes](#modality-codes).
+
+### Accelerated inference with TensorRT (CT only)
+
+Pass an extra `-x ./configs/config_trt.json` to the CT paired-inference command:
+
+```bash
+python -m scripts.inference \
+    -t ./configs/config_network_rflow.json \
+    -i ./configs/config_infer.json \
+    -e ./configs/environment_rflow-ct.json \
+    --random-seed 0 --version rflow-ct \
+    -x ./configs/config_trt.json
+```
+
+[`config_trt.json`](../configs/config_trt.json) uses MONAI's `trt_compile()` to convert select modules to TensorRT, overriding their definitions from `config_infer.json`.
 
 ## Recommended Spacing for CT
 
-According to the statistics of the training data, we have recommended input parameters for the body region that are included in the training data.
-The Recommended `"output_size"` is the median value of the training data, the Recommended `"spacing"` is the median FOV (the product of `"output_size"` and `"spacing"`) divided by the Recommended `"output_size"`.
+These are the median `output_size` / `spacing` pairs in the CT training set, grouped by `body_region`.
 
 | `"body_region"` | percentage of training data | Recommended `"output_size"` | Recommended `"spacing"` [mm] |
 |:---|:---|:---|---:|
@@ -49,8 +109,7 @@ The Recommended `"output_size"` is the median value of the training data, the Re
 | ['head', 'chest', 'abdomen', 'lower'] | 0.13% | [512, 512, 384] | [1.367, 1.367, 4.603] |
 | ['head', 'chest'] | 0.10% | [512, 512, 128] | [0.645, 0.645, 2.219] |
 
-If users want to try different `"output_size"`, please adjust `"spacing"` to ensure a reasonable FOV, which is the product of `"output_size"` and `"spacing"`.
-For example,
+If you need a different `output_size`, adjust `spacing` so `output_size × spacing` keeps a reasonable FOV (e.g.):
 
 | `"output_size"` | Recommended `"spacing"` |
 |:---|:---|
@@ -58,97 +117,11 @@ For example,
 | [512, 512, 128] | [0.8, 0.8, 2.5] |
 | [512, 512, 512] | [1.0, 1.0, 1.0] |
 
-## Execute Inference for Paired Image/Mask Generation
-
-To run the inference script including controlnet with MAISI DDPM for CT, please set `"num_inference_steps": 1000` in `../configs/config_infer.json`, and run:
-
-```bash
-export MONAI_DATA_DIRECTORY=<dir_you_will_download_data>
-network="ddpm"
-generate_version="ddpm-ct"
-python -m scripts.inference -t ./configs/config_network_${network}.json -i ./configs/config_infer.json -e ./configs/environment_${generate_version}.json --random-seed 0 --version ${generate_version}
-```
-
-To run the inference script with MAISI RFlow for CT, please set `"num_inference_steps": 30` in `../configs/config_infer.json`, and run the code above with:
-
-```bash
-network="rflow"
-generate_version="rflow-ct"
-```
-
-Currently we do not have controlnet for MRI, since MR image have very large variability and we did not train a controlnet for whole body MRI.
-
-If GPU OOM happens, please increase `autoencoder_tp_num_splits` or reduce `autoencoder_sliding_window_infer_size` in `../configs/config_infer.json`.
-To reduce time cost, please reduce `autoencoder_sliding_window_infer_overlap` in `../configs/config_infer.json`, while monitoring whether stitching artifact occurs.
-
-Please refer to [inference_tutorial.ipynb](../inference_tutorial.ipynb) for the inference tutorial that generates paired CT image and mask.
-
-**Accelerated Inference with TensorRT**:
-To run the inference script with TensorRT acceleration, please add `-x ./configs/config_trt.json` to the code above, e.g.:
-
-```bash
-export MONAI_DATA_DIRECTORY=<dir_you_will_download_data>
-network="rflow"
-generate_version="rflow-ct"
-python -m scripts.inference -t ./configs/config_network_${network}.json -i ./configs/config_infer.json -e ./configs/environment_${generate_version}.json --random-seed 0 --version ${generate_version} -x ./configs/config_trt.json
-```
-
-Extra config file, [../configs/config_trt.json](../configs/config_trt.json) is using `trt_compile()` utility from MONAI to convert select modules to TensorRT by overriding their definitions from [../configs/config_infer.json](../configs/config_infer.json).
-
-## Execute Inference for Image-Only Generation
-
-To run the inference script including controlnet with MAISI DDPM for CT, please set `"num_inference_steps": 1000` in `../configs/config_infer.json`, and run:
-
-```bash
-network="ddpm"
-generate_version="ddpm-ct"
-python -m scripts.download_model_data --version ${generate_version} --root_dir "./" --model_only
-python -m scripts.diff_model_infer -t ./configs/config_network_${network}.json -e ./configs/environment_maisi_diff_model_${generate_version}.json -c ./configs/config_maisi_diff_model_${generate_version}.json
-```
-
-To run the inference script with MAISI RFlow for CT, please run the code above with:
-
-```bash
-network="rflow"
-generate_version="rflow-ct"
-```
-
-To run the inference script with MAISI RFlow for MRI, please run the code above with:
-
-```bash
-network="rflow"
-generate_version="rflow-mr"
-```
-
-Please refer to [inference_tutorial.ipynb](../inference_tutorial.ipynb) for the inference tutorial that generates paired CT image and mask.
-
-## Quality Check
-
-We have implemented a quality check function for the generated CT images. The main idea behind this function is to ensure that the Hounsfield units (HU) intensity for each organ in the CT images remains within a defined range. For each training image used in the Diffusion network, we computed the median value for a few major organs. Then we summarize the statistics of these median values and save it to [../configs/image_median_statistics_ct.json](../configs/image_median_statistics_ct.json). During inference, for each generated image, we compute the median HU values for the major organs and check whether they fall within the normal range.
-
-For inference time cost and GPU memory usage, see [Performance](performance.md).
-
-## MR Modality Control
-
-For MR image generation, you can control the output contrast by changing `"modality"` in [../configs/config_maisi_diff_model_rflow-mr.json](../configs/config_maisi_diff_model_rflow-mr.json) according to [../configs/modality_mapping.json](../configs/modality_mapping.json):
-
-```json
-"mri": 8,
-"mri_t1": 9,
-"mri_t2": 10,
-"mri_flair": 11
-```
-
-Currently supported MR contrasts:
-
-- T1 and thick-slice T2 images for brain MRI
-- Flair for skull-stripped brain MRI
-
 ## Recommended FOV for MR `rflow-mr` model
 
-Recommended FOV is computed from median FOV of training data.
+Recommended FOV is computed from the median FOV of the training data.
 
-| Body region | Modality | number of training data | Median FOV x × y × z (mm) |
+| Body region | Modality | Number of training images | Median FOV x × y × z (mm) |
 |---|---|---:|---|
 | brain | mri_t1 (9) | 4,659 | 160.0 × 256.0 × 256.0 |
 | brain | mri_t2 (10) | 577 | 240.0 × 240.0 × 162.5 |
@@ -158,4 +131,91 @@ Recommended FOV is computed from median FOV of training data.
 | abdomen | mri_t1 (9) | 715 | 380.0 × 308.8 × 288.0 |
 | abdomen | mri_t2 (10) | 78 | 350.0 × 350.0 × 245.6 |
 
-Contrast-enhanced MRI is not supported.
+Contrast-enhanced MRI is not supported. For brain MRI, prefer the dedicated `rflow-mr-brain` model — see below.
+
+## Recommended FOV for MR `rflow-mr-brain` model
+
+Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N` counts unique source images; whole-brain and skull-stripped share the same FOV since they're two preprocessings of the same subject. Total unique images per skull condition: **323 221**.
+
+| Modality | Plane | Median FOV (mm) | N |
+|---|---|---|---:|
+| T1 | axial | 240 × 240 × 174 | 47 810 |
+| T1 | sagittal | 176 × 250 × 250 | 69 268 |
+| T1 | coronal | 240 × 200 × 240 | 38 756 |
+| T2 | axial | 240 × 240 × 158 | 195 |
+| T2 | sagittal | 162 × 240 × 240 | 551 |
+| T2 | coronal | 200 × 180 × 200 | 125 |
+| FLAIR | axial | 250 × 250 × 175 | 27 990 |
+| FLAIR | sagittal | 176 × 250 × 250 | 58 421 |
+| FLAIR | coronal | 250 × 200 × 250 | 27 698 |
+| SWI | axial | 230 × 230 × 145 | 47 859 |
+| SWI | sagittal | 140 × 230 × 230 | 2 |
+| SWI | coronal | 230 × 155 × 230 | 4 |
+| MRA | axial | 220 × 220 × 158 | 37 |
+| MRA | sagittal | 158 × 250 × 250 | 98 |
+| MRA | coronal | 240 × 179 × 240 | 11 |
+
+Pick the row matching your target acquisition plane, then pick the modality code for the skull condition you want (`9..20` whole-brain or `29..32` skull-stripped — see [Modality codes](#modality-codes)). Set `dim` and `spacing` so `dim[i] × spacing[i]` matches the median FOV; the slice-stacking axis (smallest FOV) should map to the smaller `dim` axis: axial → `dim[2]=128`, sagittal → `dim[0]=128`, coronal → `dim[1]=128`.
+
+## Modality codes
+
+Control the MR contrast (and skull-stripping state for `rflow-mr-brain`) by setting `"modality"` in the variant's `config_maisi_diff_model_*.json`. Full mapping in [`configs/modality_mapping.json`](../configs/modality_mapping.json).
+
+| Code | Modality | Used by |
+|---:|---|---|
+| 1 | CT | `rflow-ct`, `ddpm-ct` (always) |
+| 8 | mri (unspecified contrast) | `rflow-mr` |
+| 9 | mri_t1 | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
+| 10 | mri_t2 | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
+| 11 | mri_flair | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
+| 20 | mri_swi | `rflow-mr-brain` (whole-brain) |
+| 29 | mri_t1_skull_stripped | `rflow-mr-brain` (skull-stripped) |
+| 30 | mri_t2_skull_stripped | `rflow-mr-brain` (skull-stripped) |
+| 31 | mri_flair_skull_stripped | `rflow-mr-brain` (skull-stripped) |
+| 32 | mri_swi_skull_stripped | `rflow-mr-brain` (skull-stripped) |
+
+## Configuration parameter reference
+
+The user-facing config knobs live in [`../configs/config_infer.json`](../configs/config_infer.json) (paired pipeline) and `../configs/config_maisi_diff_model_<variant>.json` (image-only pipelines).
+
+| Key | Purpose |
+|---|---|
+| `num_output_samples` | Number of output samples to generate. |
+| `output_size` (paired) / `dim` (image-only) | Output volume shape in voxels. Must be divisible by 16. Reduce if GPU memory is limited. |
+| `spacing` | Voxel size in mm. `output_size × spacing` = FOV. See the recommended-FOV tables above for the training distribution. |
+| `controllable_anatomy_size` | (Paired CT only) List of `[organ_name, size]` tuples — e.g. `[["liver", 0.5], ["hepatic tumor", 0.3]]`. Triggers Path A (diffusion-generated mask) when non-empty. |
+| `body_region` | (Paired `ddpm-ct` only when `controllable_anatomy_size` is empty) One or more of `head`, `chest`, `thorax`, `abdomen`, `pelvis`, `lower`. Deprecated for `rflow-ct` — leave `[]`. |
+| `anatomy_list` | List of organ names from [`configs/label_dict.json`](../configs/label_dict.json) to keep in the output mask. |
+| `modality` | Modality code — see [Modality codes](#modality-codes). |
+| `num_inference_steps` | RFlow → 30, DDPM → 1000 (mandatory; lower values warn and degrade). For the mask DM, always 1000. |
+| `cfg_guidance_scale_modality` | Image-only path: classifier-free guidance on the modality. CT → 0, MR → 10 (shipped defaults — keep). |
+| `cfg_guidance_scale_tumor` | Paired CT path: classifier-free guidance on tumor presence. `0` (default) = off. `1..5` = stronger tumor enforcement. |
+| `autoencoder_sliding_window_infer_size` | AE-decode ROI per tile (paired pipeline only — hardcoded `[80,80,80]` in `diff_model_infer`). Must be divisible by 16. Larger = fewer tiles, more VRAM. |
+| `autoencoder_sliding_window_infer_overlap` | `[0, 1)`. Higher = smoother seams, more compute. |
+| `autoencoder_tp_num_splits` | `∈ {1, 2, 4, 8, 16}`. Higher = lower per-GPU VRAM, slower. |
+
+For validated `(GPU memory, output_size) → (AE sliding-window knobs)` presets, see the "How to configure a run" section of [`infer_mask-image-paired`](../skills/infer_mask-image-paired.md).
+
+## Quality check (CT only)
+
+The paired CT pipeline runs a quality check after each generated image: for each major organ, it verifies the **median HU intensity** falls within the per-organ range stored in [`configs/image_median_statistics_ct.json`](../configs/image_median_statistics_ct.json). If any organ is an outlier, the mask + image are regenerated (up to 2 retries). MR variants skip this check.
+
+For inference time cost and GPU memory usage, see [Performance](performance.md).
+
+## Tuning checklist
+
+- **GPU OOM** → reduce `autoencoder_sliding_window_infer_size` (must stay divisible by 16) or raise `autoencoder_tp_num_splits` to the next value in `{2, 4, 8, 16}`.
+- **Seam / stitching artifacts** → raise `autoencoder_sliding_window_infer_overlap` toward `0.6667`.
+- **Speed** → lower the overlap toward `0.25`, then enlarge the sliding-window size if VRAM permits.
+- **Washed-out MR contrast** → check `cfg_guidance_scale_modality` is at the shipped default of 10 (not 0).
+- **Unusable output despite valid inputs** → FOV is probably out-of-distribution for the variant. Match a row in the FOV tables above.
+
+## Architecture
+
+The pipeline trains an autoencoder in pixel space to encode images into latent features, then trains a diffusion model in the latent space. During inference, latent features are generated from random noise via denoising steps, then decoded by the autoencoder.
+
+![Training scheme](../figures/maisi_train.png)
+
+![Inference scheme](../figures/maisi_infer.png)
+
+Network definitions: [config_network_rflow.json](../configs/config_network_rflow.json), [config_network_ddpm.json](../configs/config_network_ddpm.json). Key references: [Latent Diffusion (CVPR 2022)](https://openaccess.thecvf.com/content/CVPR2022/papers/Rombach_High-Resolution_Image_Synthesis_With_Latent_Diffusion_Models_CVPR_2022_paper.pdf), [ControlNet (ICCV 2023)](https://openaccess.thecvf.com/content/ICCV2023/papers/Zhang_Adding_Conditional_Control_to_Text-to-Image_Diffusion_Models_ICCV_2023_paper.pdf), [Rectified Flow (ICLR 2023)](https://arxiv.org/pdf/2209.03003).

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -139,6 +139,8 @@ Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N
 
 > ℹ️ The table covers axial, sagittal, and coronal scans only. The training set also includes images acquired in oblique orientations (not summarized here); the model has seen those during training but they are excluded from this reference table because the axial/sagittal/coronal cases are what users typically request at inference.
 
+> ⚠️ **MRA** has very few training images across all three planes (37 / 98 / 11), so output quality at `mri_mra` (16) / `mri_mra_skull_stripped` (33) is not guaranteed.
+
 | Modality | Plane | Median FOV (mm) | N |
 |---|---|---|---:|
 | T1 | axial | 240 × 240 × 174 | 47 810 |

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -135,7 +135,7 @@ Contrast-enhanced MRI is not supported. For brain MRI, prefer the dedicated `rfl
 
 ## Recommended FOV for MR `rflow-mr-brain` model
 
-Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N` counts unique source images; whole-brain and skull-stripped share the same FOV since they're two preprocessings of the same subject. Total unique images per skull condition: **323 221**.
+Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N` counts unique source images; whole-brain and skull-stripped share the same FOV since they're two preprocessings of the same subject. Total unique images per skull condition (sum of the rows below): **318 825**.
 
 | Modality | Plane | Median FOV (mm) | N |
 |---|---|---|---:|
@@ -155,7 +155,7 @@ Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N
 | MRA | sagittal | 158 × 250 × 250 | 98 |
 | MRA | coronal | 240 × 179 × 240 | 11 |
 
-Pick the row matching your target acquisition plane, then pick the modality code for the skull condition you want (`9..20` whole-brain or `29..32` skull-stripped — see [Modality codes](#modality-codes)). Set `dim` and `spacing` so `dim[i] × spacing[i]` matches the median FOV; the slice-stacking axis (smallest FOV) should map to the smaller `dim` axis: axial → `dim[2]=128`, sagittal → `dim[0]=128`, coronal → `dim[1]=128`.
+Pick the row matching your target acquisition plane, then pick the modality code for the skull condition you want (`9..20` whole-brain or `29..33` skull-stripped — see [Modality codes](#modality-codes)). Set `dim` and `spacing` so `dim[i] × spacing[i]` matches the median FOV; the slice-stacking axis (smallest FOV) should map to the smaller `dim` axis: axial → `dim[2]=128`, sagittal → `dim[0]=128`, coronal → `dim[1]=128`.
 
 ## Modality codes
 
@@ -168,11 +168,13 @@ Control the MR contrast (and skull-stripping state for `rflow-mr-brain`) by sett
 | 9 | mri_t1 | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
 | 10 | mri_t2 | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
 | 11 | mri_flair | `rflow-mr`, `rflow-mr-brain` (whole-brain) |
+| 16 | mri_mra | `rflow-mr-brain` (whole-brain) |
 | 20 | mri_swi | `rflow-mr-brain` (whole-brain) |
 | 29 | mri_t1_skull_stripped | `rflow-mr-brain` (skull-stripped) |
 | 30 | mri_t2_skull_stripped | `rflow-mr-brain` (skull-stripped) |
 | 31 | mri_flair_skull_stripped | `rflow-mr-brain` (skull-stripped) |
 | 32 | mri_swi_skull_stripped | `rflow-mr-brain` (skull-stripped) |
+| 33 | mri_mra_skull_stripped | `rflow-mr-brain` (skull-stripped) |
 
 ## Configuration parameter reference
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -138,7 +138,7 @@ Contrast-enhanced MRI is not supported. For brain MRI, prefer the dedicated `rfl
 Median FOV per (modality, acquisition plane) across the MR-RATE training set. `N` counts unique source images; whole-brain and skull-stripped share the same FOV since they're two preprocessings of the same subject. Total unique images per skull condition (sum of the rows below): **318 825**.
 
 > ℹ️ The table covers axial, sagittal, and coronal scans only. The training set also includes images acquired in oblique orientations (not summarized here); the model has seen those during training but they are excluded from this reference table because the axial/sagittal/coronal cases are what users typically request at inference.
-
+>
 > ⚠️ **MRA** has very few training images across all three planes (37 / 98 / 11), so output quality at `mri_mra` (16) / `mri_mra_skull_stripped` (33) is not guaranteed.
 
 | Modality | Plane | Median FOV (mm) | N |


### PR DESCRIPTION
Two independent doc-only changes, extracted from #issue-29 for a fast review.

  - **`docs/inference.md`** — reorganized top-down: overview → run command per
  variant → recommended FOV (CT, `rflow-mr`, `rflow-mr-brain`) → parameter
  reference → tuning checklist → architecture. Adds the previously-missing
  `rflow-mr-brain` run command and a new `rflow-mr-brain` per-(modality ×
  acquisition plane) FOV table.
  - **README** — live-demo link `build.nvidia.com/nvidia/maisi` →
  `huggingface.co/spaces/nvidia/nv-generate`.