### PR TITLE
Add train_controlnet_image-from-mask skill

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -301,7 +301,7 @@ def prepare_maisi_controlnet_json_dataloader(
 
     common_transform = [
         LoadImaged(keys=["image", "label"], image_only=True, ensure_channel_first=True),
-        Orientationd(keys=["label"], axcodes="RAS"),
+        Orientationd(keys=["image", "label"], axcodes="RAS"),
         EnsureTyped(keys=["label"], dtype=torch.long, track_meta=True),
         Lambdad(keys="top_region_index", func=lambda x: torch.FloatTensor(x), allow_missing_keys=True),
         Lambdad(keys="bottom_region_index", func=lambda x: torch.FloatTensor(x), allow_missing_keys=True),

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -23,10 +23,10 @@ It explains how to produce the **three derived files** the ControlNet training l
 KiTS-000* --|-mask.nii.gz                 # original mask           ← you have this
             |-image_emb.nii.gz            # VAE-encoded embedding         (Step 1)
             |-mask_pseudo_label.nii.gz    # NV-Segment labels + body (200) (Step 2)
-            |-mask_combined_label.nii.gz  # pseudo labels + your remapped mask  (Step 3)
+            |-mask_combined_label.nii.gz  # pseudo labels + your remapped mask  (Steps 3–4)
 ```
 
-The training loop reads only `*_emb.nii.gz` (as `image`) and `*_combined_label.nii.gz` (as `label`). Steps 1–3 below produce them.
+The training loop reads only `*_emb.nii.gz` (as `image`) and `*_combined_label.nii.gz` (as `label`). Steps 1–4 below produce them.
 
 ---
 
@@ -108,13 +108,17 @@ combined[remapped > 0] = remapped[remapped > 0]
 
 (`scripts/utils.py::remap_labels` does the same thing but reads a JSON of `[orig, target]` pairs — handy if you prefer a config file. Use whichever fits your pipeline.)
 
-> **Match the label grid to the embedding (easy to miss).** Step 1 resamples the *image* to the nearest multiple of 128 per axis before encoding, so the latent is that resampled size / 4. The combined label must sit on that **same resampled grid** — i.e. its spatial size must be exactly **4× the latent per axis** — or ControlNet training errors out on a shape mismatch (there is no auto-resampling in the loop). If your original image isn't already a multiple of 128 (e.g. `512×512×167` → resampled to `512×512×128`), the pseudo/combined label built at the original resolution (`167`) will **not** match the embedding — resample it to the encoded grid with **nearest-neighbor** (integer labels; never linear/bspline):
->
-> ```python
-> import torch.nn.functional as F
-> # image_size = the resampled image shape used in Step 1 (= 4× the latent), NOT the latent size
-> combined = F.interpolate(combined.float()[None, None], size=image_size, mode="nearest")[0, 0].long()
-> ```
+---
+
+## Step 4 — Put the combined label on the encoded-image grid
+
+The combined label must sit on the **same grid Step 1 resampled the image to** (nearest multiple of 128 per axis) — i.e. spatial size = **4× the latent per axis**. The training loop does **not** auto-resample, so a mismatch errors out. If the original size isn't already a multiple of 128 (e.g. `512×512×167` → image `512×512×128`, latent `128×128×32`), resample the label there with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
+
+```python
+import torch.nn.functional as F
+# image_size = the Step-1 resampled image shape (= 4× the latent), NOT the latent size
+combined = F.interpolate(combined.float()[None, None], size=image_size, mode="nearest")[0, 0].long()
+```
 
 ---
 
@@ -128,7 +132,7 @@ One JSON pairs each embedding with its combined label. Paths are **relative to `
         {
             "image": "KiTS-000/image_emb.nii.gz",        # from Step 1
             "label": "KiTS-000/mask_combined_label.nii.gz",  # from Step 3
-            "dim": [512, 512, 512],                        # resampled volume size — informational (but the label's actual voxel grid must be 4× the latent; see Step 3b)
+            "dim": [512, 512, 512],                        # resampled volume size — informational (but the label's actual voxel grid must be 4× the latent; see Step 4)
             "spacing": [1.0, 1.0, 1.0],                    # voxel spacing
             "top_region_index": [0, 1, 0, 0],              # ddpm-ct ONLY (omit for rflow-ct)
             "bottom_region_index": [0, 0, 0, 1],           # ddpm-ct ONLY (omit for rflow-ct)
@@ -140,7 +144,7 @@ One JSON pairs each embedding with its combined label. Paths are **relative to `
 }
 ```
 
-> **`top_region_index` / `bottom_region_index` are only needed for `ddpm-ct`.** That variant's network (`config_network_ddpm.json`) sets `include_body_region: true`, so the loader feeds these body-region one-hots. `rflow-ct` (`config_network_rflow.json`) sets `include_body_region: false` and **ignores them** — you can leave them out entirely. The loader otherwise requires only `image`, `label`, and `spacing`; `dim` is informational (though the label file's actual voxel grid must be 4× the latent — see [Step 3b](#3b-combine-write-your-remapped-mask-on-top)).
+> **`top_region_index` / `bottom_region_index` are only needed for `ddpm-ct`.** That variant's network (`config_network_ddpm.json`) sets `include_body_region: true`, so the loader feeds these body-region one-hots. `rflow-ct` (`config_network_rflow.json`) sets `include_body_region: false` and **ignores them** — you can leave them out entirely. The loader otherwise requires only `image`, `label`, and `spacing`; `dim` is informational (though the label file's actual voxel grid must be 4× the latent — see [Step 4](#step-4--put-the-combined-label-on-the-encoded-image-grid)).
 
 <!-- -->
 

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -112,11 +112,13 @@ combined[remapped > 0] = remapped[remapped > 0]
 
 ## Step 4 — Put the combined label on the encoded-image grid
 
-The combined label must sit on the **same grid Step 1 resampled the image to** (nearest multiple of 128 per axis) — i.e. spatial size = **4× the latent per axis**. The training loop does **not** auto-resample, so a mismatch errors out. If the original size isn't already a multiple of 128 (e.g. `512×512×167` → image `512×512×128`, latent `128×128×32`), resample the label there with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
+The combined label must sit on the **same grid Step 1 resampled the image to** (nearest multiple of 128 per axis) — i.e. spatial size = **4× the latent per axis**. The training loop does **not** auto-resample, so a mismatch errors out.
+
+Example: original `512×512×167` → Step 1 resamples the image to **`512×512×128`** (`167`→`128`, the nearest multiple of 128) → latent `128×128×32`. So resample the label to **`512×512×128`** as well, with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
 
 ```python
 import torch.nn.functional as F
-# image_size = the Step-1 resampled image shape (= 4× the latent), NOT the latent size
+# image_size = the Step-1 resampled image shape (here [512, 512, 128]) = 4× the latent, NOT the latent size
 combined = F.interpolate(combined.float()[None, None], size=image_size, mode="nearest")[0, 0].long()
 ```
 

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -112,7 +112,7 @@ combined[remapped > 0] = remapped[remapped > 0]
 
 ## Step 4 — Put the combined label on the encoded-image grid
 
-In short: **the combined label's spatial size must be 4× the latent per axis** (the training loop does not auto-resample, so a mismatch errors out). Resample it there with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
+**The combined label's spatial size must be 4× the latent per axis** (the training loop does not auto-resample, so a mismatch errors out). Resample it there with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
 
 ```python
 import torch.nn.functional as F

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -112,13 +112,11 @@ combined[remapped > 0] = remapped[remapped > 0]
 
 ## Step 4 — Put the combined label on the encoded-image grid
 
-The combined label must sit on the **same grid Step 1 resampled the image to** (nearest multiple of 128 per axis) — i.e. spatial size = **4× the latent per axis**. The training loop does **not** auto-resample, so a mismatch errors out.
-
-Example: original `512×512×167` → Step 1 resamples the image to **`512×512×128`** (`167`→`128`, the nearest multiple of 128) → latent `128×128×32`. So resample the label to **`512×512×128`** as well, with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
+In short: **the combined label's spatial size must be 4× the latent per axis** (the training loop does not auto-resample, so a mismatch errors out). Resample it there with **nearest-neighbor** (never linear/bspline — they invent fractional class IDs):
 
 ```python
 import torch.nn.functional as F
-# image_size = the Step-1 resampled image shape (here [512, 512, 128]) = 4× the latent, NOT the latent size
+# image_size = 4× the latent, e.g. [512, 512, 128] for a 128×128×32 latent (NOT the latent size)
 combined = F.interpolate(combined.float()[None, None], size=image_size, mode="nearest")[0, 0].long()
 ```
 

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -166,9 +166,9 @@ One JSON pairs each embedding with its combined label. Paths are **relative to `
 +    "kidney tumor": 129,
 ```
 
-## Launch finetuning
+## Next: train the ControlNet
 
-Once the three files and JSON exist and the configs point at them, run the ControlNet training command from [docs/training.md → 3D ControlNet Training](../docs/training.md#3d-controlnet-training). In short:
+Once the files and JSON exist and the configs point at them, continue with the [`train_controlnet_image-from-mask`](train_controlnet_image-from-mask.md) skill — it covers the training configs, knobs (folds, `weighted_loss`, region-contrastive loss), single/multi-GPU launch, and outputs. (See also [docs/training.md → 3D ControlNet Training](../docs/training.md#3d-controlnet-training).) The short version:
 
 ```bash
 network="rflow"; generate_version="rflow-ct"

--- a/skills/finetune_image-from-mask_data-prep.md
+++ b/skills/finetune_image-from-mask_data-prep.md
@@ -103,10 +103,18 @@ remapped = remap_labels(your_mask, {1: 1, 2: 5, 3: 129})
 # 3b: write your foreground classes on top, leave the organ/body context intact
 combined = pseudo.clone()
 combined[remapped > 0] = remapped[remapped > 0]
-# save `combined` as mask_combined_label*.nii.gz (same affine/spacing as the pseudo label)
+# save `combined` as mask_combined_label*.nii.gz
 ```
 
 (`scripts/utils.py::remap_labels` does the same thing but reads a JSON of `[orig, target]` pairs — handy if you prefer a config file. Use whichever fits your pipeline.)
+
+> **Match the label grid to the embedding (easy to miss).** Step 1 resamples the *image* to the nearest multiple of 128 per axis before encoding, so the latent is that resampled size / 4. The combined label must sit on that **same resampled grid** — i.e. its spatial size must be exactly **4× the latent per axis** — or ControlNet training errors out on a shape mismatch (there is no auto-resampling in the loop). If your original image isn't already a multiple of 128 (e.g. `512×512×167` → resampled to `512×512×128`), the pseudo/combined label built at the original resolution (`167`) will **not** match the embedding — resample it to the encoded grid with **nearest-neighbor** (integer labels; never linear/bspline):
+>
+> ```python
+> import torch.nn.functional as F
+> # image_size = the resampled image shape used in Step 1 (= 4× the latent), NOT the latent size
+> combined = F.interpolate(combined.float()[None, None], size=image_size, mode="nearest")[0, 0].long()
+> ```
 
 ---
 
@@ -120,7 +128,7 @@ One JSON pairs each embedding with its combined label. Paths are **relative to `
         {
             "image": "KiTS-000/image_emb.nii.gz",        # from Step 1
             "label": "KiTS-000/mask_combined_label.nii.gz",  # from Step 3
-            "dim": [512, 512, 512],                        # resampled volume size — informational
+            "dim": [512, 512, 512],                        # resampled volume size — informational (but the label's actual voxel grid must be 4× the latent; see Step 3b)
             "spacing": [1.0, 1.0, 1.0],                    # voxel spacing
             "top_region_index": [0, 1, 0, 0],              # ddpm-ct ONLY (omit for rflow-ct)
             "bottom_region_index": [0, 0, 0, 1],           # ddpm-ct ONLY (omit for rflow-ct)
@@ -132,7 +140,7 @@ One JSON pairs each embedding with its combined label. Paths are **relative to `
 }
 ```
 
-> **`top_region_index` / `bottom_region_index` are only needed for `ddpm-ct`.** That variant's network (`config_network_ddpm.json`) sets `include_body_region: true`, so the loader feeds these body-region one-hots. `rflow-ct` (`config_network_rflow.json`) sets `include_body_region: false` and **ignores them** — you can leave them out entirely. The loader otherwise requires only `image`, `label`, and `spacing`; `dim` is informational.
+> **`top_region_index` / `bottom_region_index` are only needed for `ddpm-ct`.** That variant's network (`config_network_ddpm.json`) sets `include_body_region: true`, so the loader feeds these body-region one-hots. `rflow-ct` (`config_network_rflow.json`) sets `include_body_region: false` and **ignores them** — you can leave them out entirely. The loader otherwise requires only `image`, `label`, and `spacing`; `dim` is informational (though the label file's actual voxel grid must be 4× the latent — see [Step 3b](#3b-combine-write-your-remapped-mask-on-top)).
 
 <!-- -->
 
@@ -170,6 +178,7 @@ python -m scripts.train_controlnet \
 
 - [ ] Embeddings made with **`autoencoder_v1.pt`** (not v2) for the CT ControlNet.
 - [ ] **Body envelope (`200`) added** via `scripts.utils.add_body_envelope(seg, ct)` — NV-Segment never produces it, and the ControlNet needs it on every non-organ body voxel.
+- [ ] **Combined label on the encoded-image grid** — resampled (nearest-neighbor) to the Step-1 resampled size = 4× the latent per axis, or training errors out on a shape mismatch.
 - [ ] New classes remapped to **any unclaimed integer in `0–255`** (free ranges `133–199` / `201–255`, or a `dummy` slot like `129`); existing organs remapped to their real MAISI indices. Never reuse a claimed index, `0`, or `200`.
 - [ ] `label_dict.json` has a named entry for any new index. (Optional: `weighted_loss_label` set if you want to emphasize an ROI such as a tumor.)
 - [ ] Items spread across **multiple folds** so the held-out (validation) fold isn't the whole dataset.

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -33,7 +33,7 @@ The loop consumes **one thing per training case: a `(image, label)` pair**, list
 | JSON key | File | On-disk shape | What it is |
 |---|---|---|---|
 | `image` | `*_emb.nii.gz` | `[X/4, Y/4, Z/4, 4]` | The **VAE latent embedding** of the real image — a **4-channel** float volume saved channel-*last* (a 4D NIfTI), produced by the AE encoder in data-prep Step 1. |
-| `label` | `*_combined_label.nii.gz` | `[X, Y, Z]` | The **combined integer label mask** — a plain **3D** volume (no channel axis): MAISI-vocabulary organ labels + body envelope `200` + your ROI/class, on the **encoded-image grid**. |
+| `label` | `*_combined_label.nii.gz` | `[X, Y, Z]` | The **combined integer label mask** — a plain **3D** volume (no channel axis): MAISI-vocabulary organ labels + body envelope `200` + your ROI/class, on the **same grid as the image that was VAE-encoded** (so its spatial size is 4× the latent). |
 
 The loader (`LoadImaged(..., ensure_channel_first=True)`) moves/adds the channel axis to the **front** in memory, so downstream the tensors are channel-first: image → `[4, X/4, Y/4, Z/4]`, label → `[1, X, Y, Z]` (`C=1`, a single integer channel). Shapes in the rest of this section use that channel-first `[C, X, Y, Z]` form.
 
@@ -117,6 +117,8 @@ F.interpolate(label.float(), size=image_size, mode="nearest").long()
 
 ### Training config (`-c`) — the `controlnet_train` knobs
 
+The shipped `config_maisi_controlnet_train_rflow-ct.json` (values as delivered — this is the real default, **not** a disabled template):
+
 ```json
 "controlnet_train": {
     "batch_size": 1,          // images trained whole (not patched); keep at 1
@@ -124,13 +126,16 @@ F.interpolate(label.float(), size=image_size, mode="nearest").long()
     "fold": 0,                // items whose "fold" == this validate; the rest train
     "lr": 1e-5,               // AdamW LR, polynomial-decayed to 0 over all steps
     "n_epochs": 100,          // total training epochs
-    "weighted_loss_label": [None],  // label index(es) to up-weight in L1; [None] = off
-    "weighted_loss": 1              // multiplier on those voxels; 1 = all voxels equal (off)
+    "weighted_loss_label": [23],  // ROI/class index(es) up-weighted in L1 (23 = lung tumor)
+    "weighted_loss": 100,         // multiplier on those voxels; set to 1 to weight all voxels equally
+    "use_region_contrasive_loss": true,   // rflow-ct default (see caveat below)
+    "region_contrasive_loss_delta": 2,
+    "region_contrasive_loss_weight": 0.01
 }
 ```
 
-- **`weighted_loss` / `weighted_loss_label`** — optional; up-weight the L1 loss on a small/hard ROI (e.g. a tumor label). Set the label to your ROI index and `weighted_loss > 1` (e.g. `100`); leave `weighted_loss: 1` (and `[None]`) to weight all voxels equally.
-- Optional **region-contrastive loss** (`use_region_contrasive_loss` + `region_contrasive_loss_delta` + `region_contrasive_loss_weight`) exists but its default `remove_roi()` assumes a MAISI **tumor** ROI (`remove_tumors`). For a general vocabulary, leave it off unless you edit `remove_roi()` in `train_controlnet.py`.
+- **`weighted_loss` / `weighted_loss_label`** — up-weight the L1 loss on a small/hard ROI (e.g. a tumor). Set `weighted_loss_label` to **your** ROI/class index (the CT config ships `[23]`; the MR/ddpm configs ship `[129]`). To disable emphasis entirely, use `"weighted_loss": 1` with `"weighted_loss_label": [null]`.
+- **Region-contrastive loss** — on by default in `rflow-ct` (the `ddpm-ct` / `rflow-mr` configs omit these three keys, i.e. off). Its `remove_roi()` assumes a MAISI **tumor** ROI (`remove_tumors`); for any other vocabulary, edit `remove_roi()` in `train_controlnet.py` or set `use_region_contrasive_loss: false`.
 
 ## Launch
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -77,7 +77,11 @@ The `label` is a 1-channel **integer** mask. During training it is converted to 
 
 The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine — the ControlNet downsamples the label 4× internally to add it to the latent, and there's no auto-resampling, so a mismatch errors out. Data prep puts the label on that grid; see [data-prep Step 4](finetune_image-from-mask_data-prep.md#step-4--put-the-combined-label-on-the-encoded-image-grid).
 
-> The loader orients the **label** to RAS but uses the **image** embedding as-is (no orientation). Make sure the embedding was created in the same orientation as the label, or the two will silently misalign.
+### Orientation — label and embedding must agree
+
+The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. If the two were saved in different orientations, the label gets rotated/flipped to RAS while the embedding is not — so voxel `(i,j,k)` of the label no longer corresponds to voxel `(i,j,k)` of the latent, and the ControlNet trains on a spatially scrambled mask. **No error is raised**; the model just learns from misaligned pairs.
+
+They already agree if data-prep produced both from one source image (the label is then already RAS and the reorientation is a no-op). The risk is only with hand-assembled or externally-sourced files — verify the embedding and label share an orientation before training.
 
 ---
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -63,7 +63,7 @@ The autoencoder downsamples by **4× per spatial axis**, so a `[512, 512, 128]` 
 
 Field notes (from the loader transforms):
 
-- **`image` / `label`** — required. `label` is oriented to **RAS** and cast to **`long`** (integer); `image` is used as-is.
+- **`image` / `label`** — required. Both are oriented to **RAS**; `label` is additionally cast to **`long`** (integer).
 - **`spacing`** — required; converted to a float tensor and scaled ×100 as a conditioning input.
 - **`modality`** — mapped to an integer via `modality_mapping_path` ([`configs/modality_mapping.json`](../configs/modality_mapping.json), e.g. `"ct"→1`, `"mri_t2"→10`). Required whenever the diffusion U-Net has modality conditioning — i.e. `diffusion_unet_def.num_class_embeds` is non-null, which gates `include_modality` (it's `128` in the shipped rflow/ddpm nets, so required there).
 - **`fold`** *(easy to get backwards)* — an item is held out for **validation** when its `"fold"` **equals** `fold` in the training config (default `0`), and used for **training** otherwise. If every item is `fold: 0` with the default config, the **training set is empty**. Spread items across folds (`0`, `1`, `2`, …).
@@ -77,11 +77,7 @@ The `label` is a 1-channel **integer** mask. During training it is converted to 
 
 The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine — the ControlNet downsamples the label 4× internally to add it to the latent, and there's no auto-resampling, so a mismatch errors out. Data prep puts the label on that grid; see [data-prep Step 4](finetune_image-from-mask_data-prep.md#step-4--put-the-combined-label-on-the-encoded-image-grid).
 
-### Orientation — label and embedding must agree
-
-The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. Standard embeddings are already RAS — `diff_model_create_training_data.py` orients each image to RAS before encoding — so the label→RAS step brings the label into that same frame, and the current label-only transform is enough.
-
-Adding `"image"` to that transform is a harmless hardening: a no-op for standard (already-RAS) embeddings, and it would realign a non-standard, non-RAS embedding too — `Orientationd` only permutes/flips axes losslessly, so it can't corrupt latent values, as long as the embedding's affine faithfully encodes its orientation. The only unrecoverable case is an embedding whose affine doesn't match its voxels, which no affine-based tool can fix. Without that guard, a non-RAS embedding misaligns with the RAS label and the ControlNet trains on a spatially scrambled mask with **no error raised**.
+The loader orients both `image` and `label` to canonical RAS, so their axes always agree.
 
 ---
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -79,9 +79,9 @@ The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 
 
 ### Orientation — label and embedding must agree
 
-The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. If the two were saved in different orientations, the label gets rotated/flipped to RAS while the embedding is not — so voxel `(i,j,k)` of the label no longer corresponds to voxel `(i,j,k)` of the latent, and the ControlNet trains on a spatially scrambled mask. **No error is raised**; the model just learns from misaligned pairs.
+The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. This is deliberate, not a gap: the embedding script (`diff_model_create_training_data.py`) orients each image to RAS *before* encoding, so standard embeddings are **already RAS**. The label→RAS step just brings the label into that same frame — adding `"image"` to the transform would be a no-op.
 
-They already agree if data-prep produced both from one source image (the label is then already RAS and the reorientation is a no-op). The risk is only with hand-assembled or externally-sourced files — verify the embedding and label share an orientation before training.
+The only way to misalign is to feed an embedding **not** made by that script (in a different orientation): the label gets flipped to RAS, the latent does not, and the ControlNet trains on a spatially scrambled mask with **no error raised**. Fix it at the source — regenerate the embedding with the standard script — rather than reorienting a latent at load time (its axes flip losslessly, but the VAE isn't flip-equivariant and a hand-set affine may not describe it faithfully).
 
 ---
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -1,6 +1,6 @@
 ---
 name: train_controlnet_image-from-mask
-description: How to train a 3D image-from-mask ControlNet with scripts.train_controlnet — for any modality (CT or MR) and any label vocabulary. Focuses on the training-data format the loop consumes (paired VAE latent embedding + combined integer label mask, the JSON data list schema, required vs conditional fields, the label→8-bit binary condition, folds, modality, multi-dataset lists) and the spatial relationship between the latent embedding and the label (the label must be at the encoded-image grid = 4× the latent per axis; the ControlNet downsamples it internally). Covers configs, single/multi-GPU launch, key knobs (n_epochs, lr, fold, weighted_loss), and outputs. Trigger when the user asks "how do I train the ControlNet", "what is the training data format / JSON schema", "what shape must the label mask be vs the embedding", "do I resample the label to match the latent and how", "how do I train a ControlNet for a new modality or vocabulary", or "which config/command trains train_controlnet".
+description: How to train a 3D image-from-mask ControlNet with scripts.train_controlnet — for any modality (CT or MR) and any label vocabulary. Focuses on the training-data format the loop consumes (paired VAE latent embedding + combined integer label mask, the JSON data list schema, required vs conditional fields, the label→8-bit binary condition, folds, modality, multi-dataset lists) and the spatial relationship between the latent embedding and the label (the label must be on the same grid as the image that was VAE-encoded = 4× the latent per axis; the ControlNet downsamples it internally). Covers configs, single/multi-GPU launch, key knobs (n_epochs, lr, fold, weighted_loss), and outputs. Trigger when the user asks "how do I train the ControlNet", "what is the training data format / JSON schema", "what shape must the label mask be vs the embedding", "do I resample the label to match the latent and how", "how do I train a ControlNet for a new modality or vocabulary", or "which config/command trains train_controlnet".
 ---
 
 # Training an image-from-mask ControlNet
@@ -13,14 +13,14 @@ This skill covers training a 3D ControlNet with `scripts.train_controlnet`, for 
 
 ## How training is wired
 
-`scripts/train_controlnet.py` always needs a **frozen pretrained diffusion U-Net** (`trained_diffusion_path`) and its autoencoder — those are *not* the ControlNet. The training:
+`scripts/train_controlnet.py` needs a **frozen pretrained diffusion U-Net** (`trained_diffusion_path`) — *not* the ControlNet. The training:
 
 1. Loads the frozen DM, reads its `scale_factor`, sets every U-Net param `requires_grad = False`.
 2. Builds the ControlNet and **initializes it by copying the DM's encoder/mid weights** (`copy_model_state`).
 3. Optionally loads a ControlNet checkpoint from **`existing_ckpt_filepath`** to continue/finetune. Leave it `null` to start from the DM-copied init; set it to a checkpoint path to warm-start — your choice.
 4. Trains **only** the ControlNet (AdamW, L1 loss, `PolynomialLR` power 2.0), saving after every epoch.
 
-You always supply the pretrained **AE + DM** for your modality (`autoencoder_v1` + `diff_unet_3d_rflow-ct` for CT; `autoencoder_v2` + `diff_unet_3d_rflow-mr` for MR).
+The DM you supply must match your modality (`diff_unet_3d_rflow-ct` for CT; `diff_unet_3d_rflow-mr` for MR). The **autoencoder is not loaded by this script** — it is used earlier, in data-prep, to produce the `*_emb.nii.gz` embeddings; by training time the `image` is already a latent. (`trained_autoencoder_path` may appear in the env config but the trainer ignores it.)
 
 ---
 
@@ -65,7 +65,7 @@ Field notes (from the loader transforms):
 
 - **`image` / `label`** — required. `label` is oriented to **RAS** and cast to **`long`** (integer); `image` is used as-is.
 - **`spacing`** — required; converted to a float tensor and scaled ×100 as a conditioning input.
-- **`modality`** — mapped to an integer via `modality_mapping_path` ([`configs/modality_mapping.json`](../configs/modality_mapping.json), e.g. `"ct"→1`, `"mri_t2"→…`). Required whenever the network has modality conditioning (`num_class_embeds` set — true for the shipped rflow/ddpm nets).
+- **`modality`** — mapped to an integer via `modality_mapping_path` ([`configs/modality_mapping.json`](../configs/modality_mapping.json), e.g. `"ct"→1`, `"mri_t2"→10`). Required whenever the diffusion U-Net has modality conditioning — i.e. `diffusion_unet_def.num_class_embeds` is non-null, which gates `include_modality` (it's `128` in the shipped rflow/ddpm nets, so required there).
 - **`fold`** *(easy to get backwards)* — an item is held out for **validation** when its `"fold"` **equals** `fold` in the training config (default `0`), and used for **training** otherwise. If every item is `fold: 0` with the default config, the **training set is empty**. Spread items across folds (`0`, `1`, `2`, …).
 - **`top_region_index` / `bottom_region_index`** — 4-D body-region one-hots, needed **only** for `ddpm-ct` (`config_network_ddpm.json` sets `include_body_region: true`). `rflow` nets set it `false` and ignore them.
 
@@ -80,11 +80,14 @@ The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 
 To get this, resample the label onto the **same grid as the image** using **nearest-neighbor** (linear/bspline average integer IDs into wrong classes):
 
 ```python
-# Resample the label to the encoded-image spatial size; nearest preserves class IDs.
+# image_size = the pre-encoding image shape (i.e. 4× the latent), NOT the latent size.
+# nearest preserves class IDs.
 Resized(keys="label", spatial_size=image_size, mode="nearest")
 # or, torch:
 F.interpolate(label.float(), size=image_size, mode="nearest").long()
 ```
+
+> The loader orients the **label** to RAS but uses the **image** embedding as-is (no orientation). Make sure the embedding was created in the same orientation as the label, or the two will silently misalign.
 
 ---
 
@@ -101,7 +104,7 @@ F.interpolate(label.float(), size=image_size, mode="nearest").long()
 
 ```json
 {
-    "trained_autoencoder_path": "./models/autoencoder_v1.pt",       // v1 for CT, v2 for MR
+    "trained_autoencoder_path": "./models/autoencoder_v1.pt",       // present but NOT read by train_controlnet.py
     "trained_diffusion_path":  "./models/diff_unet_3d_rflow-ct.pt", // frozen DM (REQUIRED, non-null)
     "existing_ckpt_filepath":  null,                                // null, or a ControlNet ckpt to warm-start
     "exp_name": "my_controlnet",                                    // names the output checkpoints
@@ -171,11 +174,13 @@ torchrun --nproc_per_node=${NUM_GPUS_PER_NODE} --nnodes=1 \
 
 ## Version selection
 
-| `generate_version` | Network (`-t`) | AE / DM to supply | `include_body_region` |
-|---|---|---|---|
-| `rflow-ct` *(recommended CT)* | `config_network_rflow.json` | `autoencoder_v1` + `diff_unet_3d_rflow-ct` | `false` — omit region indices |
-| `ddpm-ct` | `config_network_ddpm.json` | `autoencoder_v1` + `diff_unet_3d_ddpm-ct` | `true` — JSON needs `top/bottom_region_index` |
-| `rflow-mr` | `config_network_rflow.json` | `autoencoder_v2` + `diff_unet_3d_rflow-mr` | `false` |
+"AE (data-prep)" is the autoencoder used earlier to build the embeddings; "DM (`-e`)" is the frozen diffusion U-Net this script loads.
+
+| `generate_version` | Network (`-t`) | AE (data-prep) | DM (`-e`) | `include_body_region` |
+|---|---|---|---|---|
+| `rflow-ct` *(recommended CT)* | `config_network_rflow.json` | `autoencoder_v1` | `diff_unet_3d_rflow-ct` | `false` — omit region indices |
+| `ddpm-ct` | `config_network_ddpm.json` | `autoencoder_v1` | `diff_unet_3d_ddpm-ct` | `true` — JSON needs `top/bottom_region_index` |
+| `rflow-mr` | `config_network_rflow.json` | `autoencoder_v2` | `diff_unet_3d_rflow-mr` | `false` |
 
 ## GPU memory (whole-image training, per docs)
 
@@ -201,7 +206,7 @@ TensorBoard scalars go to `tfevent_path/exp_name`. To generate with the result, 
 
 - [ ] Per case: `image` = 4-channel latent embedding, `label` = 1-channel integer mask at **4× the latent per axis** (same FOV/affine as the encoded image).
 - [ ] Label resampled with **nearest-neighbor** only — never linear/bspline.
-- [ ] `trained_diffusion_path` (frozen DM) set and **required**; AE/DM match the modality. (`existing_ckpt_filepath`: `null`, or a ControlNet ckpt to warm-start.)
+- [ ] `trained_diffusion_path` (frozen DM) set and **required**, matching the modality; the AE is a data-prep dependency, not read by this script. (`existing_ckpt_filepath`: `null`, or a ControlNet ckpt to warm-start.)
 - [ ] `-c` / `-e` are the **`*_controlnet_train_*`** configs, not `*_diff_model_*`.
 - [ ] Items spread across **multiple folds** so the held-out (validation) fold isn't the whole dataset.
 - [ ] `modality` present in every entry + `modality_mapping_path` set (net uses modality conditioning).

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -1,0 +1,204 @@
+---
+name: train_controlnet_image-from-mask
+description: How to train a 3D image-from-mask ControlNet with scripts.train_controlnet — for any modality (CT or MR) and any label vocabulary. Focuses on the training-data format the loop consumes (paired VAE latent embedding + combined integer label mask, the JSON data list schema, required vs conditional fields, the label→8-bit binary condition, folds, modality, multi-dataset lists) and the spatial relationship between the latent embedding and the label (the label must be at the encoded-image grid = 4× the latent per axis; the ControlNet downsamples it internally). Covers configs, single/multi-GPU launch, key knobs (n_epochs, lr, fold, weighted_loss), and outputs. Trigger when the user asks "how do I train the ControlNet", "what is the training data format / JSON schema", "what shape must the label mask be vs the embedding", "do I resample the label to match the latent and how", "how do I train a ControlNet for a new modality or vocabulary", or "which config/command trains train_controlnet".
+---
+
+# Training an image-from-mask ControlNet
+
+This skill covers training a 3D ControlNet with `scripts.train_controlnet`, for **any modality (CT or MR) and any label vocabulary**. It sits between:
+
+1. **Prepare data** → [`finetune_image-from-mask_data-prep`](finetune_image-from-mask_data-prep.md) produces the two per-case files (`*_emb.nii.gz`, `*_combined_label.nii.gz`) + the JSON data list.
+2. **Train** ← *you are here.*
+3. **Generate** → [`infer_image-from-mask`](infer_image-from-mask.md) runs the trained checkpoint on a mask.
+
+## How training is wired
+
+`scripts/train_controlnet.py` always needs a **frozen pretrained diffusion U-Net** (`trained_diffusion_path`) and its autoencoder — those are *not* the ControlNet. The training:
+
+1. Loads the frozen DM, reads its `scale_factor`, sets every U-Net param `requires_grad = False`.
+2. Builds the ControlNet and **initializes it by copying the DM's encoder/mid weights** (`copy_model_state`).
+3. Optionally loads a ControlNet checkpoint from **`existing_ckpt_filepath`** to continue/finetune. Leave it `null` to start from the DM-copied init; set it to a checkpoint path to warm-start — your choice.
+4. Trains **only** the ControlNet (AdamW, L1 loss, `PolynomialLR` power 2.0), saving after every epoch.
+
+You always supply the pretrained **AE + DM** for your modality (`autoencoder_v1` + `diff_unet_3d_rflow-ct` for CT; `autoencoder_v2` + `diff_unet_3d_rflow-mr` for MR).
+
+---
+
+## Training data format
+
+The loop consumes **one thing per training case: a `(image, label)` pair**, listed in a JSON data list. `scripts/utils.py::prepare_maisi_controlnet_json_dataloader` loads it; the loader does **no spatial resampling** — the files must already be on compatible grids (see below).
+
+### Per-case files
+
+| JSON key | File | On-disk shape | What it is |
+|---|---|---|---|
+| `image` | `*_emb.nii.gz` | `[X/4, Y/4, Z/4, 4]` | The **VAE latent embedding** of the real image — a **4-channel** float volume saved channel-*last* (a 4D NIfTI), produced by the AE encoder in data-prep Step 1. |
+| `label` | `*_combined_label.nii.gz` | `[X, Y, Z]` | The **combined integer label mask** — a plain **3D** volume (no channel axis): MAISI-vocabulary organ labels + body envelope `200` + your ROI/class, on the **encoded-image grid**. |
+
+The loader (`LoadImaged(..., ensure_channel_first=True)`) moves/adds the channel axis to the **front** in memory, so downstream the tensors are channel-first: image → `[4, X/4, Y/4, Z/4]`, label → `[1, X, Y, Z]` (`C=1`, a single integer channel). Shapes in the rest of this section use that channel-first `[C, X, Y, Z]` form.
+
+The autoencoder downsamples by **4× per spatial axis**, so a `[512, 512, 128]` image encodes to a `[4, 128, 128, 32]` latent (channel-first), while its `label` stays on the image grid → `[1, 512, 512, 128]`, i.e. 4× the latent per spatial axis. (Inside the loop that single label channel is expanded to **8 channels** by `binarize_labels` → `[8, 512, 512, 128]` — see [the condition](#the-label-vocabulary-and-how-it-becomes-the-condition) below.)
+
+### JSON data list schema
+
+`data_base_dir` + `json_data_list` are **lists** (one entry each per dataset — you can mix datasets). Paths inside each JSON are **relative to** that JSON's `data_base_dir`. The `"training"` array holds the cases:
+
+```jsonc
+{
+  "training": [
+    {
+      "image": "case_000/img_emb.nii.gz",       // REQUIRED — latent embedding, on disk [X/4, Y/4, Z/4, 4]
+      "label": "case_000/combined_label.nii.gz", // REQUIRED — integer mask, on disk [X, Y, Z]
+      "spacing": [1.0, 1.0, 1.0],                // REQUIRED — voxel spacing of the encoded image (mm)
+      "modality": "ct",                          // REQUIRED when the network uses modality conditioning
+      "fold": 0,                                 // REQUIRED — cross-val fold (see semantics below)
+      "dim": [512, 512, 128],                    // informational only (not read by the loader)
+      "top_region_index": [0, 1, 0, 0],          // ddpm-ct ONLY — omit for rflow-ct / rflow-mr
+      "bottom_region_index": [0, 0, 0, 1]        // ddpm-ct ONLY — omit for rflow-ct / rflow-mr
+    }
+    // ... more cases
+  ]
+}
+```
+
+Field notes (from the loader transforms):
+
+- **`image` / `label`** — required. `label` is oriented to **RAS** and cast to **`long`** (integer); `image` is used as-is.
+- **`spacing`** — required; converted to a float tensor and scaled ×100 as a conditioning input.
+- **`modality`** — mapped to an integer via `modality_mapping_path` ([`configs/modality_mapping.json`](../configs/modality_mapping.json), e.g. `"ct"→1`, `"mri_t2"→…`). Required whenever the network has modality conditioning (`num_class_embeds` set — true for the shipped rflow/ddpm nets).
+- **`fold`** *(easy to get backwards)* — an item is held out for **validation** when its `"fold"` **equals** `fold` in the training config (default `0`), and used for **training** otherwise. If every item is `fold: 0` with the default config, the **training set is empty**. Spread items across folds (`0`, `1`, `2`, …).
+- **`top_region_index` / `bottom_region_index`** — 4-D body-region one-hots, needed **only** for `ddpm-ct` (`config_network_ddpm.json` sets `include_body_region: true`). `rflow` nets set it `false` and ignore them.
+
+### The label vocabulary and how it becomes the condition
+
+The `label` is a 1-channel **integer** mask. During training it is converted to the ControlNet condition by `binarize_labels` — an **8-bit binary encoding** → 8 channels (`conditioning_embedding_in_channels: 8`). That is why the ControlNet supports **up to 256 labels (0–255)**. Use the MAISI 132-class vocabulary + body `200`, plus any new-class index you assigned in data-prep. Values are integer class IDs — **never** continuous. (Label authoring, remapping, and adding a new class: see the data-prep skill.)
+
+### Spatial relationship — label vs. embedding (important)
+
+The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine. The ControlNet downsamples the label by 4× internally to add it to the latent; there's no auto-resampling, so a mismatched axis errors out.
+
+To get this, resample the label onto the **same grid as the image** using **nearest-neighbor** (linear/bspline average integer IDs into wrong classes):
+
+```python
+# Resample the label to the encoded-image spatial size; nearest preserves class IDs.
+Resized(keys="label", spatial_size=image_size, mode="nearest")
+# or, torch:
+F.interpolate(label.float(), size=image_size, mode="nearest").long()
+```
+
+---
+
+## The three config files you pass
+
+| Flag | File | Role |
+|---|---|---|
+| `-t` | `configs/config_network_${network}.json` | Network architecture (`rflow` or `ddpm`). Sets `include_body_region`. |
+| `-c` | `configs/config_maisi_controlnet_train_${generate_version}.json` | `controlnet_train` hyper-parameters. |
+| `-e` | `configs/environment_maisi_controlnet_train_${generate_version}.json` | Paths: weights, data, outputs. |
+| `-g` | — | Number of GPUs (`1` = single-GPU, no DDP). |
+
+### Environment config (`-e`) — key fields
+
+```json
+{
+    "trained_autoencoder_path": "./models/autoencoder_v1.pt",       // v1 for CT, v2 for MR
+    "trained_diffusion_path":  "./models/diff_unet_3d_rflow-ct.pt", // frozen DM (REQUIRED, non-null)
+    "existing_ckpt_filepath":  null,                                // null, or a ControlNet ckpt to warm-start
+    "exp_name": "my_controlnet",                                    // names the output checkpoints
+    "model_dir":  "./models/",
+    "tfevent_path": "./outputs/tfevent",
+    "data_base_dir": ["./datasets/my_dataset"],                     // LIST
+    "json_data_list": ["./datasets/my_dataset.json"],              // LIST (paired with data_base_dir)
+    "modality_mapping_path": "./configs/modality_mapping.json"      // required when net uses modality
+}
+```
+
+> To warm-start from a ControlNet checkpoint, set **`existing_ckpt_filepath`** — the training loop reads that key (train_controlnet.py:309), *not* `trained_controlnet_path`. (The stale `environment_maisi_controlnet_train.json` uses the old `trained_controlnet_path` key, which the trainer ignores — prefer the versioned `_rflow-ct` / `_rflow-mr` / `_ddpm-ct` env configs.)
+
+### Training config (`-c`) — the `controlnet_train` knobs
+
+```json
+"controlnet_train": {
+    "batch_size": 1,          // images trained whole (not patched); keep at 1
+    "cache_rate": 0.0,        // MONAI CacheDataset ratio; raise if RAM allows
+    "fold": 0,                // items whose "fold" == this validate; the rest train
+    "lr": 1e-5,               // AdamW LR, polynomial-decayed to 0 over all steps
+    "n_epochs": 100,          // total training epochs
+    "weighted_loss_label": [None],  // label index(es) to up-weight in L1; [None] = off
+    "weighted_loss": 1              // multiplier on those voxels; 1 = all voxels equal (off)
+}
+```
+
+- **`weighted_loss` / `weighted_loss_label`** — optional; up-weight the L1 loss on a small/hard ROI (e.g. a tumor label). Set the label to your ROI index and `weighted_loss > 1` (e.g. `100`); leave `weighted_loss: 1` (and `[None]`) to weight all voxels equally.
+- Optional **region-contrastive loss** (`use_region_contrasive_loss` + `region_contrasive_loss_delta` + `region_contrasive_loss_weight`) exists but its default `remove_roi()` assumes a MAISI **tumor** ROI (`remove_tumors`). For a general vocabulary, leave it off unless you edit `remove_roi()` in `train_controlnet.py`.
+
+## Launch
+
+### Single GPU
+
+```bash
+network="rflow"; generate_version="rflow-ct"      # CT; or rflow-mr, or network=ddpm/generate_version=ddpm-ct
+
+python -m scripts.train_controlnet \
+    -t ./configs/config_network_${network}.json \
+    -c ./configs/config_maisi_controlnet_train_${generate_version}.json \
+    -e ./configs/environment_maisi_controlnet_train_${generate_version}.json \
+    -g 1
+```
+
+> The single-GPU snippet in [docs/training.md](../docs/training.md#execute-training) mistakenly passes the `config_maisi_diff_model_*` / `environment_maisi_diff_model_*` files — those lack a `controlnet_train` block. Use the **`*_controlnet_train_*`** configs above.
+
+### Multi-GPU (torchrun / DDP)
+
+`-g` must equal `--nproc_per_node`; DDP kicks in whenever `-g > 1`.
+
+```bash
+export NUM_GPUS_PER_NODE=8
+network="rflow"; generate_version="rflow-ct"
+torchrun --nproc_per_node=${NUM_GPUS_PER_NODE} --nnodes=1 \
+    --master_addr=localhost --master_port=1234 \
+    -m scripts.train_controlnet \
+    -t ./configs/config_network_${network}.json \
+    -c ./configs/config_maisi_controlnet_train_${generate_version}.json \
+    -e ./configs/environment_maisi_controlnet_train_${generate_version}.json \
+    -g ${NUM_GPUS_PER_NODE}
+```
+
+## Version selection
+
+| `generate_version` | Network (`-t`) | AE / DM to supply | `include_body_region` |
+|---|---|---|---|
+| `rflow-ct` *(recommended CT)* | `config_network_rflow.json` | `autoencoder_v1` + `diff_unet_3d_rflow-ct` | `false` — omit region indices |
+| `ddpm-ct` | `config_network_ddpm.json` | `autoencoder_v1` + `diff_unet_3d_ddpm-ct` | `true` — JSON needs `top/bottom_region_index` |
+| `rflow-mr` | `config_network_rflow.json` | `autoencoder_v2` + `diff_unet_3d_rflow-mr` | `false` |
+
+## GPU memory (whole-image training, per docs)
+
+| Image size | Latent size | Peak memory |
+|---|---|---|
+| 256×256×128 | 4×64×64×32 | 5 G |
+| 256×256×256 | 4×64×64×64 | 8 G |
+| 512×512×128 | 4×128×128×32 | 12 G |
+| 512×512×256 | 4×128×128×64 | 21 G |
+| 512×512×512 | 4×128×128×128 | 39 G |
+| 512×512×768 | 4×128×128×192 | 58 G |
+
+## Outputs
+
+Written to `model_dir`, named by `exp_name`, each holding `{epoch, loss, controlnet_state_dict}`:
+
+- **`{exp_name}_current.pt`** — overwritten every epoch (latest).
+- **`{exp_name}_best.pt`** — written when the epoch loss improves.
+
+TensorBoard scalars go to `tfevent_path/exp_name`. To generate with the result, point the inference env's `trained_controlnet_path` at your `{exp_name}_best.pt` (the checkpoint format matches what inference loads) and follow [`infer_image-from-mask`](infer_image-from-mask.md).
+
+## Gotchas checklist
+
+- [ ] Per case: `image` = 4-channel latent embedding, `label` = 1-channel integer mask at **4× the latent per axis** (same FOV/affine as the encoded image).
+- [ ] Label resampled with **nearest-neighbor** only — never linear/bspline.
+- [ ] `trained_diffusion_path` (frozen DM) set and **required**; AE/DM match the modality. (`existing_ckpt_filepath`: `null`, or a ControlNet ckpt to warm-start.)
+- [ ] `-c` / `-e` are the **`*_controlnet_train_*`** configs, not `*_diff_model_*`.
+- [ ] Items spread across **multiple folds** so the held-out (validation) fold isn't the whole dataset.
+- [ ] `modality` present in every entry + `modality_mapping_path` set (net uses modality conditioning).
+- [ ] `ddpm-ct` only: entries carry `top_region_index` / `bottom_region_index`; `rflow` ignores them.
+- [ ] `data_base_dir` / `json_data_list` are **lists**; label values are integers in `0–255`.

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -79,9 +79,9 @@ The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 
 
 ### Orientation — label and embedding must agree
 
-The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. This is deliberate, not a gap: the embedding script (`diff_model_create_training_data.py`) orients each image to RAS *before* encoding, so standard embeddings are **already RAS**. The label→RAS step just brings the label into that same frame — adding `"image"` to the transform would be a no-op.
+The loader reorients the **label** to canonical **RAS** (`Orientationd(keys=["label"], axcodes="RAS")`) but loads the **image** embedding **as-is**. Standard embeddings are already RAS — `diff_model_create_training_data.py` orients each image to RAS before encoding — so the label→RAS step brings the label into that same frame, and the current label-only transform is enough.
 
-The only way to misalign is to feed an embedding **not** made by that script (in a different orientation): the label gets flipped to RAS, the latent does not, and the ControlNet trains on a spatially scrambled mask with **no error raised**. Fix it at the source — regenerate the embedding with the standard script — rather than reorienting a latent at load time (its axes flip losslessly, but the VAE isn't flip-equivariant and a hand-set affine may not describe it faithfully).
+Adding `"image"` to that transform is a harmless hardening: a no-op for standard (already-RAS) embeddings, and it would realign a non-standard, non-RAS embedding too — `Orientationd` only permutes/flips axes losslessly, so it can't corrupt latent values, as long as the embedding's affine faithfully encodes its orientation. The only unrecoverable case is an embedding whose affine doesn't match its voxels, which no affine-based tool can fix. Without that guard, a non-RAS embedding misaligns with the RAS label and the ControlNet trains on a spatially scrambled mask with **no error raised**.
 
 ---
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -75,17 +75,7 @@ The `label` is a 1-channel **integer** mask. During training it is converted to 
 
 ### Spatial relationship — label vs. embedding (important)
 
-The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine. The ControlNet downsamples the label by 4× internally to add it to the latent; there's no auto-resampling, so a mismatched axis errors out.
-
-To get this, resample the label onto the **same grid as the image** using **nearest-neighbor** (linear/bspline average integer IDs into wrong classes):
-
-```python
-# image_size = the pre-encoding image shape (i.e. 4× the latent), NOT the latent size.
-# nearest preserves class IDs.
-Resized(keys="label", spatial_size=image_size, mode="nearest")
-# or, torch:
-F.interpolate(label.float(), size=image_size, mode="nearest").long()
-```
+The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine — the ControlNet downsamples the label 4× internally to add it to the latent, and there's no auto-resampling, so a mismatch errors out. Data prep puts the label on that grid (nearest-neighbor); see [data-prep Step 4](finetune_image-from-mask_data-prep.md#step-4--put-the-combined-label-on-the-encoded-image-grid).
 
 > The loader orients the **label** to RAS but uses the **image** embedding as-is (no orientation). Make sure the embedding was created in the same orientation as the label, or the two will silently misalign.
 

--- a/skills/train_controlnet_image-from-mask.md
+++ b/skills/train_controlnet_image-from-mask.md
@@ -75,7 +75,7 @@ The `label` is a 1-channel **integer** mask. During training it is converted to 
 
 ### Spatial relationship — label vs. embedding (important)
 
-The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine — the ControlNet downsamples the label 4× internally to add it to the latent, and there's no auto-resampling, so a mismatch errors out. Data prep puts the label on that grid (nearest-neighbor); see [data-prep Step 4](finetune_image-from-mask_data-prep.md#step-4--put-the-combined-label-on-the-encoded-image-grid).
+The **label must be exactly 4× the latent per spatial axis** (e.g. latent `[4, 128, 128, 32]` → label `[1, 512, 512, 128]`) and share the image's FOV/affine — the ControlNet downsamples the label 4× internally to add it to the latent, and there's no auto-resampling, so a mismatch errors out. Data prep puts the label on that grid; see [data-prep Step 4](finetune_image-from-mask_data-prep.md#step-4--put-the-combined-label-on-the-encoded-image-grid).
 
 > The loader orients the **label** to RAS but uses the **image** embedding as-is (no orientation). Make sure the embedding was created in the same orientation as the label, or the two will silently misalign.
 


### PR DESCRIPTION
Skill for training the 3D image-from-mask ControlNet (scripts.train_controlnet), covering the training-data format (paired VAE latent embedding + combined integer label mask, JSON data list schema, folds, modality), the label↔latent 4x spatial relationship with nearest-neighbor resampling, configs, single/multi-GPU launch, key knobs, and outputs.